### PR TITLE
Remove description and add version hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,9 +575,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -618,7 +618,7 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "mcexport"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "hickory-resolver",
@@ -1445,9 +1445,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1490,18 +1490,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ rust-version = "1.75.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 axum = { version = "0.7", default-features = false, features = ["http1", "tokio", "tower-log", "tracing", "query"] }
 tracing = "0.1"
-serde = { version = "1.0.214", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-hickory-resolver = "0.24.1"
-thiserror = "2.0.3"
-prometheus-client = "0.22.3"
-tracing-subscriber = "0.3.18"
-tower-http = { version = "0.6.1", features = ["trace"] }
+hickory-resolver = "0.24"
+thiserror = "2"
+prometheus-client = "0.22"
+tracing-subscriber = "0.3"
+tower-http = { version = "0.6", features = ["trace"] }
 
 [dev-dependencies]
 serde_test = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,8 +2,6 @@ mod ping;
 mod probe;
 mod protocol;
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use crate::ping::{get_server_status, ProbeStatus};
 use crate::probe::ProbingInfo;
 use crate::probe::ResolutionResult::{Plain, Srv};
@@ -19,6 +17,8 @@ use prometheus_client::encoding::text::encode;
 use prometheus_client::metrics::family::Family;
 use prometheus_client::metrics::gauge::Gauge;
 use prometheus_client::registry::Registry;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
@@ -151,9 +151,7 @@ impl IntoResponse for ProbeStatus {
                 "The numeric hash of the visual network protocol",
                 protocol_hash.clone(),
             );
-            protocol_hash
-                .get_or_create(&())
-                .set(hasher.finish() as i64);
+            protocol_hash.get_or_create(&()).set(hasher.finish() as i64);
 
             // favicon bytes (gauge)
             let favicon_bytes = Family::<(), Gauge<u32, AtomicU32>>::default();

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -72,16 +72,6 @@ pub struct ServerPlayers {
     pub sample: Option<Vec<ServerPlayer>>,
 }
 
-/// The MOTD of a pinged server within the different formats.
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-pub enum ServerDescription {
-    /// The MOTD was configured/reported with legacy formatting (plain text).
-    Plain(String),
-    /// The MOTD was configured/reported with text components (rich text).
-    Component { text: String },
-}
-
 /// The self-reported status of a pinged server with all public metadata.
 #[derive(Debug, Deserialize)]
 pub struct ServerStatus {
@@ -89,8 +79,6 @@ pub struct ServerStatus {
     pub version: ServerVersion,
     /// The current, maximum and sampled players of the server.
     pub players: ServerPlayers,
-    /// The MOTD (Motto Of The Day) of the server.
-    pub description: ServerDescription,
     /// The optional favicon of the server.
     pub favicon: Option<String>,
 }
@@ -151,7 +139,6 @@ pub async fn get_server_status(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ping::ServerDescription::{Component, Plain};
 
     #[test]
     fn deserialize_component_description() {
@@ -167,12 +154,6 @@ mod tests {
         assert_eq!(4, status.players.online);
         assert_eq!(6, status.players.max);
         assert_eq!(sample, status.players.sample);
-        match status.description {
-            Component { text: des } => assert_eq!("description text", des),
-            _ => {
-                panic!("unexpected description type")
-            }
-        };
         assert_eq!(favicon, status.favicon);
         assert_eq!(favicon, status.favicon);
     }
@@ -191,12 +172,6 @@ mod tests {
         assert_eq!(6, status.players.online);
         assert_eq!(8, status.players.max);
         assert_eq!(sample, status.players.sample);
-        match status.description {
-            Plain(des) => assert_eq!("description text 2", des),
-            _ => {
-                panic!("unexpected description type")
-            }
-        };
         assert_eq!(favicon, status.favicon);
     }
 }


### PR DESCRIPTION
We remove the description information for now, as it makes the deserialization more difficult and it's not exported anyway.

This also adds `mcexport_protocol_version_hash` to find matching textual versions or changes more easily.

Fixes #5 