### PR TITLE
Add timeout handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,10 +5,11 @@ mod protocol;
 use crate::ping::{get_server_status, ProbeStatus};
 use crate::probe::ProbingInfo;
 use crate::probe::ResolutionResult::{Plain, Srv};
+use crate::TimeoutError::NegativeDuration;
 use axum::body::Body;
 use axum::extract::{Query, State};
-use axum::http::header::CONTENT_TYPE;
-use axum::http::StatusCode;
+use axum::http::header::{ToStrError, CONTENT_TYPE};
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
@@ -20,9 +21,12 @@ use prometheus_client::registry::Registry;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::net::SocketAddr;
+use std::num::ParseFloatError;
 use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::TcpListener;
+use tokio::time::timeout;
 use tower_http::trace::TraceLayer;
 use tracing::{info, instrument, warn};
 use tracing_subscriber::filter::LevelFilter;
@@ -30,19 +34,52 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{fmt, Layer};
 
+/// The name of the request header from Prometheus, that sets the scrape timeout.
+///
+/// This header should always be present on requests from Prometheus and can contain floating point numbers. This time
+/// is the overall scraping time allocated for this probe request. Therefore, the [TIMEOUT_OFFSET_SECS] is subtracted
+/// from the time to account for network latency and other processing overheads, not part of the timeout.
+const SCRAPE_TIMEOUT_HEADER: &str = "X-Prometheus-Scrape-Timeout-Seconds";
+
+/// The default timeout length that should be used if no specific header is set.
+const DEFAULT_TIMEOUT_SECS: f64 = 120.0;
+
+/// The offset that should always be subtracted from the timeout to account for latency and other overheads.
+const TIMEOUT_OFFSET_SECS: f64 = 0.25;
+
 /// The public response error wrapper for all errors that can be relayed to the caller.
 ///
 /// This wraps all errors of the child modules into their own error type, so that they can be forwarded to the caller
 /// of the probe requests. Those errors occur while trying to assemble the response for a specific probe and are then
 /// wrapped into a parent type so that they can be more easily traced.
 #[derive(thiserror::Error, Debug)]
-pub enum Error {
+enum Error {
     /// An error occurred while reading or writing to the underlying byte stream.
     #[error("failed to resolve the intended target address: {0}")]
-    ProbeError(#[source] probe::Error, ProbingInfo),
+    ProbeFail(#[source] probe::Error, ProbingInfo),
     /// An error occurred while reading or writing to the underlying byte stream.
     #[error("failed to communicate with the target server: {0}")]
-    PingError(#[source] ping::Error, ProbingInfo),
+    PingFail(#[source] ping::Error, ProbingInfo),
+    /// An error occurred while trying to read and parse the supplied timeout.
+    #[error("failed to parse timeout header: {0}")]
+    TimeoutInvalid(#[source] TimeoutError, ProbingInfo),
+    /// The supplied timeout expired before the response was there.
+    #[error("scrape timeout expired while waiting for a response")]
+    TimeoutExpired(ProbingInfo),
+}
+
+/// The internal timeout error wrapper for all errors that occur while parsing the timeout.
+#[derive(thiserror::Error, Debug)]
+enum TimeoutError {
+    /// An error occurred while trying to read the header value into an ASCII string.
+    #[error("not all bytes are ascii printable: {0}")]
+    InvalidChars(#[source] ToStrError),
+    /// An error occurred while trying to parse the header value into a float.
+    #[error("the value \"{1}\" could not be parsed into a float: {0}")]
+    InvalidNumber(#[source] ParseFloatError, String),
+    /// The calculated timeout value would end up negative with the offset.
+    #[error("the resulting duration ended up being negative: {result:?} (original {original:?})")]
+    NegativeDuration { original: f64, result: f64 },
 }
 
 /// AppState contains various, shared resources for the state of the application.
@@ -51,7 +88,7 @@ pub enum Error {
 /// and configuration. The access is handled through [Arc], allowing for multiple threads to use the same resource
 /// without any problems regarding thread safety.
 #[derive(Debug)]
-pub struct AppState {
+struct AppState {
     pub resolver: TokioAsyncResolver,
 }
 
@@ -59,7 +96,10 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         // notify in the log (as we don't see it otherwise)
         match &self {
-            Self::ProbeError(_, info) | Self::PingError(_, info) => warn!(
+            Self::ProbeFail(_, info)
+            | Self::PingFail(_, info)
+            | Self::TimeoutInvalid(_, info)
+            | Self::TimeoutExpired(info) => warn!(
                 cause = self.to_string(),
                 target = info.target.to_string(),
                 module = info.module,
@@ -223,26 +263,43 @@ async fn handle_root() -> Response {
 /// send [info][ProbeInfo] on the corresponding target, and this endpoint will answer with the status and metrics of
 /// this ping operation. The ping is only started once the request comes in and Prometheus is responsible for scheduling
 /// the requests to this endpoint regularly.
-#[instrument(skip(state, info), fields(target = %info.target, module = %info.module.clone().unwrap_or_else(|| "-".to_string())))]
+#[instrument(skip(state, info), fields(target = %info.target, module = %info.module.clone().unwrap_or_else(|| "-".to_string())
+))]
 async fn handle_probe(
+    headers: HeaderMap,
     Query(info): Query<ProbingInfo>,
     State(state): State<Arc<AppState>>,
 ) -> Result<ProbeStatus, Error> {
-    // try to resolve the real probe address
-    let resolve_result = info
-        .target
-        .to_socket_addrs(&state.resolver)
-        .await
-        .map_err(|err| Error::ProbeError(err, info.clone()))?;
+    // get the desired timeout for this request
+    let timeout_duration =
+        get_timeout_duration(&headers).map_err(|err| Error::TimeoutInvalid(err, info.clone()))?;
 
-    // issue the status request
-    let ping_response = match resolve_result {
-        Srv(addr) => get_server_status(&info, &addr, true).await,
-        Plain(addr) => get_server_status(&info, &addr, false).await,
+    // declare the overall work to perform
+    let result = timeout(timeout_duration, async {
+        // try to resolve the real probe address
+        let resolve_result = info
+            .target
+            .to_socket_addrs(&state.resolver)
+            .await
+            .map_err(|err| Error::ProbeFail(err, info.clone()))?;
+
+        // issue the status request
+        let ping_response = match resolve_result {
+            Srv(addr) => get_server_status(&info, &addr, true).await,
+            Plain(addr) => get_server_status(&info, &addr, false).await,
+        }
+        .map_err(|err| Error::PingFail(err, info.clone()))?;
+
+        Ok(ping_response)
+    })
+    .await;
+
+    // handle timeout error and value return
+    match result {
+        Ok(Ok(status)) => Ok(status),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(Error::TimeoutExpired(info)),
     }
-    .map_err(|err| Error::PingError(err, info.clone()))?;
-
-    Ok(ping_response)
 }
 
 /// Generates a response for the supplied success state and optionally allows adding more metrics.
@@ -286,4 +343,119 @@ where
         )
         .body(Body::from(buffer))
         .expect("failed to build success target response")
+}
+
+/// Returns the desired request timeout for the probe endpoint from the supplied headers.
+///
+/// If the [SCRAPE_TIMEOUT_HEADER] is set, the value is parsed into a floating point number, that is interpreted as
+/// the duration in seconds, that will be allowed for the request. Should no such header exist, the
+/// [DEFAULT_TIMEOUT_SECS] is used instead. The duration is then reduced by [TIMEOUT_OFFSET_SECS] to account for the
+/// network latency and processing overhead that does not count into the timeout. This method never returns a negative
+/// duration and instead returns a [NegativeDuration].
+fn get_timeout_duration(headers: &HeaderMap) -> Result<Duration, TimeoutError> {
+    // try to use the header value to parse the duration
+    let header = headers.get(SCRAPE_TIMEOUT_HEADER);
+    let timeout = if let Some(raw_value) = header {
+        let value = raw_value.to_str().map_err(TimeoutError::InvalidChars)?;
+        value
+            .parse::<f64>()
+            .map_err(|err| TimeoutError::InvalidNumber(err, value.to_string()))?
+    } else {
+        DEFAULT_TIMEOUT_SECS
+    };
+
+    // subtract the timeout offset
+    let result = timeout - TIMEOUT_OFFSET_SECS;
+
+    // check whether the duration would be positive
+    if result < 0.0 {
+        return Err(NegativeDuration {
+            original: timeout,
+            result,
+        });
+    }
+
+    // wrap it into a duration object
+    Ok(Duration::from_secs_f64(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    static ILLEGAL_VALUE_BYTES: [u8; 4] = [0x00u8, 0x30u8, 0x30u8, 0x00u8];
+
+    #[test]
+    fn get_timeout_duration_with_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert(SCRAPE_TIMEOUT_HEADER, HeaderValue::from_static("5"));
+
+        assert_eq!(
+            get_timeout_duration(&headers).unwrap(),
+            Duration::from_secs_f64(5.0 - TIMEOUT_OFFSET_SECS)
+        )
+    }
+
+    #[test]
+    fn get_timeout_duration_with_header_decimal() {
+        let mut headers = HeaderMap::new();
+        headers.insert(SCRAPE_TIMEOUT_HEADER, HeaderValue::from_static("5.5"));
+
+        assert_eq!(
+            get_timeout_duration(&headers).unwrap(),
+            Duration::from_secs_f64(5.5 - TIMEOUT_OFFSET_SECS)
+        )
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_get_timeout_duration_with_invalid_header_str() {
+        let mut headers = HeaderMap::new();
+        unsafe {
+            headers.insert(
+                SCRAPE_TIMEOUT_HEADER,
+                HeaderValue::from_maybe_shared_unchecked(ILLEGAL_VALUE_BYTES.as_ref()),
+            );
+        }
+
+        get_timeout_duration(&headers).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_get_timeout_duration_with_invalid_header_parse() {
+        let mut headers = HeaderMap::new();
+        headers.insert(SCRAPE_TIMEOUT_HEADER, HeaderValue::from_static("invalid"));
+
+        get_timeout_duration(&headers).unwrap();
+    }
+
+    #[test]
+    fn get_timeout_duration_without_header() {
+        let headers = HeaderMap::new();
+
+        assert_eq!(
+            get_timeout_duration(&headers).unwrap(),
+            Duration::from_secs_f64(DEFAULT_TIMEOUT_SECS - TIMEOUT_OFFSET_SECS)
+        )
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_get_timeout_duration_negative_original() {
+        let mut headers = HeaderMap::new();
+        headers.insert(SCRAPE_TIMEOUT_HEADER, HeaderValue::from_static("-1"));
+
+        get_timeout_duration(&headers).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn fail_get_timeout_duration_negative_result() {
+        let mut headers = HeaderMap::new();
+        headers.insert(SCRAPE_TIMEOUT_HEADER, HeaderValue::from_static("0"));
+
+        get_timeout_duration(&headers).unwrap();
+    }
 }


### PR DESCRIPTION
This adds proper timeout handling and respects the timeouts set by Prometheus. Connection attempts are closed prematurely, once the timeout is reached.

Closes #4 