### PR TITLE
Optimize performance, stabilize hash and support IPv6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 rust-version = "1.88.0"
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "io-util"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "tower-log", "tracing", "query"] }
 tracing = "0.1"
 serde = { version = "1", features = ["derive"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ use std::net::SocketAddr;
 /// supported this convention, so we just go with the most recent version, which showed better results in all cases.
 ///
 /// [server-list-ping]: https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Server_List_Ping#Handshake
-pub const LATEST_PROTOCOL_VERSION: isize = 773;
+pub const LATEST_PROTOCOL_VERSION: isize = 775;
 
 /// The default socket address touple and port that mcexport should listen on.
 pub const DEFAULT_ADDRESS: ([u8; 4], u16) = ([0, 0, 0, 0], 10026);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,7 @@ use axum::http::{HeaderMap, StatusCode, header::CONTENT_TYPE};
 use axum::response::{Html, IntoResponse, Response};
 use axum::{Router, body::Body, routing::get};
 use prometheus_client::registry::Registry;
-use prometheus_client::{encoding::text::encode, metrics::family::Family, metrics::gauge::Gauge};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+use prometheus_client::{encoding::text::encode, metrics::gauge::Gauge};
 use std::sync::{Arc, atomic::AtomicU32, atomic::AtomicU64};
 use tokio::{net::TcpListener, time::timeout};
 use tower_http::trace::TraceLayer;
@@ -50,10 +48,10 @@ use tracing::{info, instrument, warn};
 /// wrapped into a parent type so that they can be more easily traced.
 #[derive(thiserror::Error, Debug)]
 enum Error {
-    /// An error occurred while reading or writing to the underlying byte stream.
+    /// An error occurred while resolving the target address.
     #[error("failed to resolve the intended target address: {0}")]
     ProbeFail(#[source] probe::Error, ProbingInfo),
-    /// An error occurred while reading or writing to the underlying byte stream.
+    /// An error occurred while pinging the target server.
     #[error("failed to communicate with the target server: {0}")]
     PingFail(#[source] ping::Error, ProbingInfo),
     /// An error occurred while trying to read and parse the supplied timeout.
@@ -90,106 +88,91 @@ impl IntoResponse for ProbeStatus {
         // return the generated metrics
         generate_metrics_response(1, |registry| {
             // ping duration (gauge)
-            let ping_duration = Family::<Vec<(String, String)>, Gauge<f64, AtomicU64>>::default();
+            let ping_duration = Gauge::<f64, AtomicU64>::default();
             registry.register(
                 "ping_duration_seconds",
                 "The duration that's elapsed since the probe request",
                 ping_duration.clone(),
             );
-            ping_duration
-                .get_or_create(&vec![])
-                .set(self.ping.as_secs_f64());
+            ping_duration.set(self.ping.as_secs_f64());
 
             // srv record (Gauge)
-            let address_srv = Family::<Vec<(String, String)>, Gauge>::default();
+            let address_srv: Gauge = Gauge::default();
             registry.register(
                 "address_srv_info",
                 "Whether there was an SRV record for the hostname",
                 address_srv.clone(),
             );
-            address_srv.get_or_create(&vec![]).set(i64::from(self.srv));
+            address_srv.set(i64::from(self.srv));
 
-            // srv record (Gauge)
-            let address_srv = Family::<Vec<(String, String)>, Gauge>::default();
+            // ping valid (Gauge)
+            let address_ping_valid: Gauge = Gauge::default();
             registry.register(
                 "address_ping_valid_info",
                 "Whether the ping response contained the correct payload",
-                address_srv.clone(),
+                address_ping_valid.clone(),
             );
-            address_srv
-                .get_or_create(&vec![])
-                .set(i64::from(self.valid));
+            address_ping_valid.set(i64::from(self.valid));
 
             // online players (gauge)
-            let players_online = Family::<Vec<(String, String)>, Gauge<u32, AtomicU32>>::default();
+            let players_online = Gauge::<u32, AtomicU32>::default();
             registry.register(
                 "players_online_total",
                 "The number of players that are currently online",
                 players_online.clone(),
             );
-            players_online
-                .get_or_create(&vec![])
-                .set(self.status.players.online);
+            players_online.set(self.status.players.online);
 
             // max players (gauge)
-            let players_max = Family::<Vec<(String, String)>, Gauge<u32, AtomicU32>>::default();
+            let players_max = Gauge::<u32, AtomicU32>::default();
             registry.register(
                 "players_max_total",
                 "The number of players that can join at maximum",
                 players_max.clone(),
             );
-            players_max
-                .get_or_create(&vec![])
-                .set(self.status.players.max);
+            players_max.set(self.status.players.max);
 
             // sample players (gauge)
-            let players_samples_count =
-                Family::<Vec<(String, String)>, Gauge<u32, AtomicU32>>::default();
+            let players_samples_count = Gauge::<u32, AtomicU32>::default();
             registry.register(
                 "players_samples_total",
                 "The number of sample entries that have been sent",
                 players_samples_count.clone(),
             );
-            players_samples_count.get_or_create(&vec![]).set(
+            let sample_count =
                 self.status
                     .players
                     .sample
-                    .map_or_else(|| 0_usize, |samples| samples.len()) as u32,
-            );
+                    .map_or_else(|| 0_usize, |samples| samples.len()) as u32;
+            players_samples_count.set(sample_count);
 
             // protocol version (gauge)
-            let protocol_version = Family::<Vec<(String, String)>, Gauge>::default();
+            let protocol_version: Gauge = Gauge::default();
             registry.register(
                 "protocol_version_info",
                 "The numeric network protocol version",
                 protocol_version.clone(),
             );
-            protocol_version
-                .get_or_create(&vec![])
-                .set(self.status.version.protocol);
+            protocol_version.set(self.status.version.protocol);
 
-            // protocol version (gauge)
-            let mut hasher = DefaultHasher::new();
-            self.status.version.name.hash(&mut hasher);
-            let protocol_hash = Family::<Vec<(String, String)>, Gauge>::default();
+            // protocol version hash (gauge) — FNV-1a for stable output across Rust versions
+            let protocol_hash: Gauge = Gauge::default();
             registry.register(
                 "protocol_version_hash",
                 "The numeric hash of the visual network protocol",
                 protocol_hash.clone(),
             );
-            protocol_hash
-                .get_or_create(&vec![])
-                .set(hasher.finish() as i64);
+            protocol_hash.set(fnv1a_hash(&self.status.version.name));
 
             // favicon bytes (gauge)
-            let favicon_bytes = Family::<Vec<(String, String)>, Gauge<u32, AtomicU32>>::default();
+            let favicon_bytes = Gauge::<u32, AtomicU32>::default();
             registry.register(
                 "favicon_bytes",
                 "The size of the favicon in bytes",
                 favicon_bytes.clone(),
             );
             let size: usize = self.status.favicon.map_or(0, |icon| icon.len());
-            favicon_bytes.get_or_create(&vec![]).set(size as u32);
+            favicon_bytes.set(size as u32);
         })
     }
 }
@@ -284,6 +267,20 @@ async fn handle_probe(
     }
 }
 
+/// Computes a FNV-1a hash of the given string as a stable i64.
+///
+/// Unlike [`std::collections::hash_map::DefaultHasher`], FNV-1a produces identical output across
+/// all Rust versions and compiler settings, making it safe for use in Prometheus gauges where a
+/// changing hash value would trigger false alerts.
+fn fnv1a_hash(s: &str) -> i64 {
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in s.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash as i64
+}
+
 /// Generates a response for the supplied success state and optionally allows adding more metrics.
 ///
 /// This initializes the [registry][Registry] for this request and registers the success metric with the supplied state
@@ -297,7 +294,7 @@ where
     let mut registry = Registry::with_prefix("mcexport");
 
     // create and register the success metric
-    let success = Family::<Vec<(String, String)>, Gauge>::default();
+    let success: Gauge = Gauge::default();
     registry.register(
         "success",
         "Whether the probe operation was successful",
@@ -305,13 +302,13 @@ where
     );
 
     // set the success status of this metric
-    success.get_or_create(&vec![]).set(success_state);
+    success.set(success_state);
 
     // add dynamic, desired metrics
     add_metrics(&mut registry);
 
-    // create a new buffer to store the metrics in
-    let mut buffer = String::new();
+    // create a new buffer to store the metrics in (pre-allocated to avoid reallocations)
+    let mut buffer = String::with_capacity(1024);
 
     // encode the metrics content into the buffer
     encode(&mut buffer, &registry).expect("failed to encode metrics into the buffer");

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 use serde_json::from_str;
 use std::net::SocketAddr;
 use std::time::Duration;
+use tokio::io::BufStream;
 use tokio::net::TcpStream;
 use tracing::{debug, instrument};
 
@@ -105,11 +106,13 @@ pub async fn get_server_status(
     srv: bool,
     fallback_protocol_version: isize,
 ) -> Result<ProbeStatus, Error> {
-    // create a new tcp stream to the target
+    // create a new tcp stream to the target, wrapped in BufStream to batch I/O
     debug!("establishing connection to target server");
-    let mut stream = TcpStream::connect(addr)
-        .await
-        .map_err(|_| Error::CannotReach)?;
+    let mut stream = BufStream::new(
+        TcpStream::connect(addr)
+            .await
+            .map_err(|_| Error::CannotReach)?,
+    );
 
     // try to use specific, requested version and fall back to "recent"
     let protocol_version = match &info.module {
@@ -167,7 +170,6 @@ mod tests {
         assert_eq!(4, status.players.online);
         assert_eq!(6, status.players.max);
         assert_eq!(sample, status.players.sample);
-        assert_eq!(favicon, status.favicon);
         assert_eq!(favicon, status.favicon);
     }
 
@@ -299,165 +301,38 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_server_status_with_mock_connection() {
-        use crate::protocol::HandshakeInfo;
-        use tokio::io::{AsyncWriteExt, duplex};
+        use crate::protocol::{HandshakeInfo, test_server};
+        use tokio::io::duplex;
 
         let (mut client, mut server) = duplex(4096);
 
-        // Spawn a task to simulate server responses
+        let response_json = r#"{"version":{"protocol":764,"name":"1.20.1"},"players":{"online":5,"max":20},"description":"Test Server"}"#;
+
         let server_task = tokio::spawn(async move {
-            use tokio::io::AsyncReadExt;
-
-            // Read handshake packet
-            let mut len_buf = [0u8; 10];
-            let mut len = 0usize;
-            let mut bytes_read = 0;
-            loop {
-                server
-                    .read_exact(&mut len_buf[bytes_read..bytes_read + 1])
-                    .await
-                    .unwrap();
-                let byte = len_buf[bytes_read];
-                len |= ((byte & 0x7F) as usize) << (7 * bytes_read);
-                bytes_read += 1;
-                if (byte & 0x80) == 0 {
-                    break;
-                }
-            }
-
-            let mut packet_buf = vec![0u8; len];
-            server.read_exact(&mut packet_buf).await.unwrap();
-
-            // Read status request packet
-            let mut len2 = 0usize;
-            let mut bytes_read2 = 0;
-            loop {
-                let mut byte_buf = [0u8; 1];
-                server.read_exact(&mut byte_buf).await.unwrap();
-                let byte = byte_buf[0];
-                len2 |= ((byte & 0x7F) as usize) << (7 * bytes_read2);
-                bytes_read2 += 1;
-                if (byte & 0x80) == 0 {
-                    break;
-                }
-            }
-
-            let mut packet_buf2 = vec![0u8; len2];
-            server.read_exact(&mut packet_buf2).await.unwrap();
-
-            // Send status response
-            let response_json = "{\"version\":{\"protocol\":764,\"name\":\"1.20.1\"},\"players\":{\"online\":5,\"max\":20},\"description\":\"Test Server\"}";
-            let mut response_payload = Vec::new();
-
-            // Write packet ID (0x00)
-            response_payload.push(0x00);
-
-            // Write string length as VarInt
-            let mut len = response_json.len();
-            loop {
-                let mut temp = (len & 0x7F) as u8;
-                len >>= 7;
-                if len != 0 {
-                    temp |= 0x80;
-                }
-                response_payload.push(temp);
-                if len == 0 {
-                    break;
-                }
-            }
-
-            // Write string bytes
-            response_payload.extend_from_slice(response_json.as_bytes());
-
-            // Write packet length as VarInt
-            let mut packet_len = response_payload.len();
-            let mut length_bytes = Vec::new();
-            loop {
-                let mut temp = (packet_len & 0x7F) as u8;
-                packet_len >>= 7;
-                if packet_len != 0 {
-                    temp |= 0x80;
-                }
-                length_bytes.push(temp);
-                if packet_len == 0 {
-                    break;
-                }
-            }
-
-            server.write_all(&length_bytes).await.unwrap();
-            server.write_all(&response_payload).await.unwrap();
-            server.flush().await.unwrap();
-
-            // Read ping packet
-            let mut ping_len = 0usize;
-            let mut ping_bytes_read = 0;
-            loop {
-                let mut byte_buf = [0u8; 1];
-                server.read_exact(&mut byte_buf).await.unwrap();
-                let byte = byte_buf[0];
-                ping_len |= ((byte & 0x7F) as usize) << (7 * ping_bytes_read);
-                ping_bytes_read += 1;
-                if (byte & 0x80) == 0 {
-                    break;
-                }
-            }
-
-            let mut ping_packet = vec![0u8; ping_len];
-            server.read_exact(&mut ping_packet).await.unwrap();
-
-            // Extract payload (skip packet ID byte, read u64)
-            let payload = u64::from_be_bytes([
-                ping_packet[1],
-                ping_packet[2],
-                ping_packet[3],
-                ping_packet[4],
-                ping_packet[5],
-                ping_packet[6],
-                ping_packet[7],
-                ping_packet[8],
-            ]);
-
-            // Send pong response
-            let mut pong_payload = Vec::new();
-            pong_payload.push(0x01); // Pong packet ID
-            pong_payload.extend_from_slice(&payload.to_be_bytes());
-
-            // Write pong packet length
-            let mut pong_len = pong_payload.len();
-            let mut pong_length_bytes = Vec::new();
-            loop {
-                let mut temp = (pong_len & 0x7F) as u8;
-                pong_len >>= 7;
-                if pong_len != 0 {
-                    temp |= 0x80;
-                }
-                pong_length_bytes.push(temp);
-                if pong_len == 0 {
-                    break;
-                }
-            }
-
-            server.write_all(&pong_length_bytes).await.unwrap();
-            server.write_all(&pong_payload).await.unwrap();
-            server.flush().await.unwrap();
+            test_server::serve_status_exchange(&mut server, response_json)
+                .await
+                .expect("mock status exchange should succeed");
+            test_server::serve_ping_exchange(&mut server)
+                .await
+                .expect("mock ping exchange should succeed");
         });
 
-        // Execute the ping protocol
         let handshake_info = HandshakeInfo::new(764, "test.server".to_string(), 25565);
-        let status_result = protocol::retrieve_status(&mut client, &handshake_info).await;
-        assert!(status_result.is_ok());
+        let status_json = protocol::retrieve_status(&mut client, &handshake_info)
+            .await
+            .expect("status retrieval should succeed");
 
-        let status_json = status_result.unwrap();
         let status: ServerStatus = from_str(&status_json).expect("could not deserialize");
-
         assert_eq!("1.20.1", status.version.name);
         assert_eq!(764, status.version.protocol);
         assert_eq!(5, status.players.online);
         assert_eq!(20, status.players.max);
 
-        let (ping, valid) = protocol::execute_ping(&mut client).await.unwrap();
+        let (ping, valid) = protocol::execute_ping(&mut client)
+            .await
+            .expect("ping should succeed");
         assert!(valid);
-        assert!(ping.as_millis() < 1000); // Should be very fast for in-memory connection
+        assert!(ping.as_millis() < 1000);
 
         server_task.await.unwrap();
     }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -12,7 +12,7 @@ use serde::de::{Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, de};
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use tracing::debug;
 
 /// The internal error type for all [`ProbingInfo`] related errors.
@@ -88,6 +88,8 @@ impl TargetAddress {
     /// The hostname of this address is resolved through DNS and is used as the IP address of the resulting socket
     /// address. To do this, we also check the SRV record for minecraft (`_minecraft._tcp`) and prefer to use this
     /// information. If any SRV record was found, the second return of this function will be true.
+    ///
+    /// IPv4 addresses are preferred over IPv6. If no IPv4 address is available, the first IPv6 address is used.
     pub async fn to_socket_addrs(
         &self,
         resolver: &TokioResolver,
@@ -129,13 +131,12 @@ impl TargetAddress {
             None => {
                 // No SRV: consume the fallback IP result already resolved in Phase A
                 let ip_response = fallback_ip_result?;
-                for ip in ip_response.iter() {
-                    debug!("resolved ip address {} for hostname {}", ip, &self.hostname);
-                    if ip.is_ipv4() {
-                        return Ok(ResolutionResult::Plain(SocketAddr::new(ip, self.port)));
-                    }
-                }
-                Err(Error::CouldNotResolveIp(self.hostname.clone()))
+                prefer_ipv4(ip_response.iter())
+                    .map(|ip| {
+                        debug!("resolved ip address {} for hostname {}", ip, &self.hostname);
+                        ResolutionResult::Plain(SocketAddr::new(ip, self.port))
+                    })
+                    .ok_or_else(|| Error::CouldNotResolveIp(self.hostname.clone()))
             }
             Some((target, target_port)) => {
                 debug!("found an SRV record for '{srv_name}': {target}:{target_port}");
@@ -146,16 +147,29 @@ impl TargetAddress {
                 } else {
                     resolver.lookup_ip(&target).await?
                 };
-                for ip in ip_response.iter() {
-                    debug!("resolved ip address {} for hostname {}", ip, &target);
-                    if ip.is_ipv4() {
-                        return Ok(ResolutionResult::Srv(SocketAddr::new(ip, target_port)));
-                    }
-                }
-                Err(Error::CouldNotResolveIp(target))
+                prefer_ipv4(ip_response.iter())
+                    .map(|ip| {
+                        debug!("resolved ip address {} for hostname {}", ip, &target);
+                        ResolutionResult::Srv(SocketAddr::new(ip, target_port))
+                    })
+                    .ok_or(Error::CouldNotResolveIp(target))
             }
         }
     }
+}
+
+/// Returns the first IPv4 address from the iterator, or the first IPv6 address if no IPv4 is present.
+fn prefer_ipv4(ips: impl Iterator<Item = IpAddr>) -> Option<IpAddr> {
+    let mut ipv6_fallback = None;
+    for ip in ips {
+        if ip.is_ipv4() {
+            return Some(ip);
+        }
+        if ipv6_fallback.is_none() {
+            ipv6_fallback = Some(ip);
+        }
+    }
+    ipv6_fallback
 }
 
 impl Display for TargetAddress {
@@ -234,6 +248,7 @@ mod tests {
     use super::*;
     use hickory_resolver::Resolver;
     use serde_test::{Token, assert_de_tokens, assert_de_tokens_error};
+    use std::net::Ipv6Addr;
 
     #[test]
     fn deserialize_without_port() {
@@ -390,5 +405,30 @@ mod tests {
             port: 25566,
         };
         probe_address.to_socket_addrs(&resolver).await.unwrap();
+    }
+
+    #[test]
+    fn prefer_ipv4_returns_ipv4_when_available() {
+        let ipv4 = IpAddr::from([127, 0, 0, 1]);
+        let ipv6 = IpAddr::from(Ipv6Addr::LOCALHOST);
+        assert_eq!(prefer_ipv4([ipv6, ipv4].into_iter()), Some(ipv4));
+    }
+
+    #[test]
+    fn prefer_ipv4_falls_back_to_ipv6_when_no_ipv4() {
+        let ipv6 = IpAddr::from(Ipv6Addr::LOCALHOST);
+        assert_eq!(prefer_ipv4([ipv6].into_iter()), Some(ipv6));
+    }
+
+    #[test]
+    fn prefer_ipv4_returns_first_ipv6_when_multiple() {
+        let first = IpAddr::from(Ipv6Addr::LOCALHOST);
+        let second = IpAddr::from(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1));
+        assert_eq!(prefer_ipv4([first, second].into_iter()), Some(first));
+    }
+
+    #[test]
+    fn prefer_ipv4_returns_none_for_empty_input() {
+        assert_eq!(prefer_ipv4(std::iter::empty()), None);
     }
 }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -78,7 +78,7 @@ impl Display for ProbingInfo {
 pub struct TargetAddress {
     /// The hostname that should be resolved to the IP address (optionally considering SRV records).
     pub hostname: String,
-    /// The post that should be used to ping the Minecraft server (ignored if SRV exists).
+    /// The port that should be used to ping the Minecraft server (ignored if SRV exists).
     pub port: u16,
 }
 
@@ -95,51 +95,66 @@ impl TargetAddress {
         // assemble the SRV record name
         let srv_name = format!("_minecraft._tcp.{}", self.hostname);
         debug!("trying to resolve SRV record: '{srv_name}'");
-        let srv_response = resolver.srv_lookup(&srv_name).await;
 
-        // check if any SRV record was present (use this data then)
-        let (hostname, port, srv_used) = srv_response.map_or_else(
-            |_| {
-                debug!("found no SRV record for '{srv_name}'");
-                (self.hostname.clone(), self.port, false)
-            },
-            |response| {
-                response.answers().iter().find_map(|rec| match &rec.data {
-                        RData::SRV(srv) => Some(srv),
-                        _ => None,
-                    })
-                    .map_or_else(
-                        || {
-                            debug!(
-                                "found an SRV record for '{srv_name}', but it was of an invalid type"
-                            );
-                            (self.hostname.clone(), self.port, false)
-                        },
-                        |record| {
-                            let target = record.target.to_utf8();
-                            let target_port = record.port;
-                            debug!("found an SRV record for '{srv_name}': {target}:{target_port}");
-                            (target, target_port, true)
-                        },
-                    )
-            },
+        // Phase A: fire both SRV lookup and fallback IP lookup concurrently so that
+        // the common case (no SRV record) only pays one DNS round trip instead of two.
+        let (srv_result, fallback_ip_result) = tokio::join!(
+            resolver.srv_lookup(&srv_name),
+            resolver.lookup_ip(self.hostname.as_str())
         );
 
-        // resolve the underlying ips for the hostname
-        let ip_response = resolver.lookup_ip(&hostname).await?;
-        for ip in ip_response.iter() {
-            debug!("resolved ip address {} for hostname {}", ip, &hostname);
-            if ip.is_ipv4() {
-                return if srv_used {
-                    Ok(ResolutionResult::Srv(SocketAddr::new(ip, port)))
+        // Extract a valid SRV target from the response, if any
+        let srv_target: Option<(String, u16)> = match srv_result {
+            Err(_) => {
+                debug!("found no SRV record for '{srv_name}'");
+                None
+            }
+            Ok(response) => {
+                match response.answers().iter().find_map(|rec| match &rec.data {
+                    RData::SRV(srv) => Some((srv.target.to_utf8(), srv.port)),
+                    _ => None,
+                }) {
+                    None => {
+                        debug!(
+                            "found an SRV record for '{srv_name}', but it was of an invalid type"
+                        );
+                        None
+                    }
+                    Some(target) => Some(target),
+                }
+            }
+        };
+
+        match srv_target {
+            None => {
+                // No SRV: consume the fallback IP result already resolved in Phase A
+                let ip_response = fallback_ip_result?;
+                for ip in ip_response.iter() {
+                    debug!("resolved ip address {} for hostname {}", ip, &self.hostname);
+                    if ip.is_ipv4() {
+                        return Ok(ResolutionResult::Plain(SocketAddr::new(ip, self.port)));
+                    }
+                }
+                Err(Error::CouldNotResolveIp(self.hostname.clone()))
+            }
+            Some((target, target_port)) => {
+                debug!("found an SRV record for '{srv_name}': {target}:{target_port}");
+                // Phase B: resolve the IP for the SRV target.
+                // If the SRV target happens to equal self.hostname, reuse the Phase A result.
+                let ip_response = if target == self.hostname {
+                    fallback_ip_result?
                 } else {
-                    Ok(ResolutionResult::Plain(SocketAddr::new(ip, port)))
+                    resolver.lookup_ip(&target).await?
                 };
+                for ip in ip_response.iter() {
+                    debug!("resolved ip address {} for hostname {}", ip, &target);
+                    if ip.is_ipv4() {
+                        return Ok(ResolutionResult::Srv(SocketAddr::new(ip, target_port)));
+                    }
+                }
+                Err(Error::CouldNotResolveIp(target))
             }
         }
-
-        // no IPv4 could be found, return an error
-        Err(Error::CouldNotResolveIp(hostname))
     }
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -441,15 +441,14 @@ where
     debug!(packet = debug(&request), "sending status request packet");
     stream.write_packet(request).await?;
 
+    // flush write buffer before reading so the server receives all packets
+    stream.flush().await?;
+
     // await the response for the status request and read it
     debug!("awaiting and reading status response packet");
     let response: StatusResponsePacket = stream.read_packet().await?;
     debug!(packet = debug(&response), "received status response packet");
 
-    debug!(
-        packet = debug(&response),
-        "received a status response packet"
-    );
     Ok(response.body)
 }
 
@@ -481,6 +480,9 @@ where
     debug!(packet = debug(&ping_request), "sending ping packet");
     stream.write_packet(ping_request).await?;
 
+    // flush write buffer before reading so the server receives the ping packet
+    stream.flush().await?;
+
     // await the retrieval of the corresponding pong packet
     debug!("awaiting and reading pong packet");
     let ping_response: PongPacket = stream.read_packet().await?;
@@ -498,10 +500,110 @@ where
     Ok((duration, true))
 }
 
+/// Test helpers that simulate the server side of the Minecraft Server List Ping protocol.
+///
+/// These allow tests to replace the ~150-line hand-rolled VarInt mock with clean calls that use
+/// the same `read_packet` / `write_packet` infrastructure as production code.
+#[cfg(test)]
+pub(crate) mod test_server {
+    use super::*;
+
+    /// Reads a handshake + status request from the client, then writes a status response.
+    pub(crate) async fn serve_status_exchange<S>(
+        stream: &mut S,
+        status_json: &str,
+    ) -> Result<(), Error>
+    where
+        S: AsyncWrite + AsyncRead + Unpin + Send + Sync,
+    {
+        let _: HandshakePacket = stream.read_packet().await?;
+        let _: StatusRequestPacket = stream.read_packet().await?;
+        stream
+            .write_packet(StatusResponsePacket {
+                body: status_json.to_string(),
+            })
+            .await?;
+        stream.flush().await?;
+        Ok(())
+    }
+
+    /// Reads a ping packet from the client and echoes the payload back as a pong.
+    pub(crate) async fn serve_ping_exchange<S>(stream: &mut S) -> Result<(), Error>
+    where
+        S: AsyncWrite + AsyncRead + Unpin + Send + Sync,
+    {
+        let ping: PingPacket = stream.read_packet().await?;
+        stream
+            .write_packet(PongPacket {
+                payload: ping.payload,
+            })
+            .await?;
+        stream.flush().await?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    impl InboundPacket for HandshakePacket {
+        async fn new_from_buffer<S>(buffer: &mut S) -> Result<Self, Error>
+        where
+            S: AsyncRead + Unpin + Send + Sync,
+        {
+            #[allow(clippy::cast_possible_wrap)]
+            let protocol_version = buffer.read_varint().await? as isize;
+            let server_address = buffer.read_string().await?;
+            let server_port = buffer.read_u16().await?;
+            let _next_state = buffer.read_varint().await?;
+            Ok(Self {
+                protocol_version,
+                server_address,
+                server_port,
+            })
+        }
+    }
+
+    impl InboundPacket for StatusRequestPacket {
+        async fn new_from_buffer<S>(_buffer: &mut S) -> Result<Self, Error>
+        where
+            S: AsyncRead + Unpin + Send + Sync,
+        {
+            Ok(Self)
+        }
+    }
+
+    impl InboundPacket for PingPacket {
+        async fn new_from_buffer<S>(buffer: &mut S) -> Result<Self, Error>
+        where
+            S: AsyncRead + Unpin + Send + Sync,
+        {
+            let payload = buffer.read_u64().await?;
+            Ok(Self { payload })
+        }
+    }
+
+    impl OutboundPacket for StatusResponsePacket {
+        async fn write_to_buffer<S>(&self, buffer: &mut S) -> Result<(), Error>
+        where
+            S: AsyncWrite + Unpin + Send + Sync,
+        {
+            buffer.write_string(&self.body).await?;
+            Ok(())
+        }
+    }
+
+    impl OutboundPacket for PongPacket {
+        async fn write_to_buffer<S>(&self, buffer: &mut S) -> Result<(), Error>
+        where
+            S: AsyncWrite + Unpin + Send + Sync,
+        {
+            buffer.write_u64(self.payload).await?;
+            Ok(())
+        }
+    }
 
     #[tokio::test]
     async fn packet_ids_valid() {


### PR DESCRIPTION
This PR optimizes the performance in multiple ways, stabilizes the hash and adds support for IPv6 targets:
* The hash for the version description is now replaced by FNV-1a, which is very fast and is stable across Rust versions. The previous implementation used the default hasher of Rust, which is explicitly **not** stable across Rust versions.
* Instead of entire metric families, plain gauges/metrics are used instead. This saves some allocations and makes the code more maintainable.
* The DNS lookup happens simultaneously for SRV/IP – If there is no  SRV record present we can then save performance because we don't have to wait on the second round trip. If the SRV record yields a result, we have to perform a third lookup.
* The stream is buffered now, so that we can save on some syscalls if there are partial writes/reads. We now only execute the minimum amount of syscalls.
* IPv6 addresses are now explicitly supported. IPv4 is preferred though.